### PR TITLE
Tabs in break finder log

### DIFF
--- a/bio_assembly_refinement/contig_break_finder.py
+++ b/bio_assembly_refinement/contig_break_finder.py
@@ -140,7 +140,7 @@ class ContigBreakFinder:
 	def _write_summary(self, contig_id, break_point, gene_name, gene_reversed, new_name, skipped):
 		'''Write summary'''
 		if (not os.path.exists(self.summary_file)) or os.stat(self.summary_file).st_size == 0:
-			header = self.summary_prefix + " " + '\t'.join(['id', 'break_point', 'gene_name', 'gene_reversed', 'new_name', 'skipped']) +'\n'
+			header = self.summary_prefix + "\t" + '\t'.join(['id', 'break_point', 'gene_name', 'gene_reversed', 'new_name', 'skipped']) +'\n'
 			utils.write_text_to_file(header, self.summary_file)
 			
 		breakpoint_to_print = break_point if break_point else '-'
@@ -154,7 +154,7 @@ class ContigBreakFinder:
 		if new_name and self.rename:
 			new_name_to_print = new_name
 		skipped_print = 'skipped' if skipped else '-'			
-		text = self.summary_prefix + " " + '\t'.join(map(str, [contig_id, breakpoint_to_print, gene_name_to_print, gene_reversed_to_print, new_name_to_print, skipped_print])) + '\n'
+		text = self.summary_prefix + "\t" + '\t'.join(map(str, [contig_id, breakpoint_to_print, gene_name_to_print, gene_reversed_to_print, new_name_to_print, skipped_print])) + '\n'
 		utils.write_text_to_file(text, self.summary_file)		
 	
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     url='https://github.com/nds/bio_assembly_refinement',
     scripts=glob.glob('scripts/*'),
     test_suite='nose.collector',
-    install_requires=['nose >= 1.3', 'pyfastaq >= 3.10.0'],
+    tests_require=['nose >= 1.3'],
+    install_requires=['pyfastaq >= 3.10.0'],
     license='GPLv3',
 )

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     url='https://github.com/nds/bio_assembly_refinement',
     scripts=glob.glob('scripts/*'),
     test_suite='nose.collector',
-    install_requires=['nose >= 1.3', 'pyfastaq >= 3.5.0'],
+    install_requires=['nose >= 1.3', 'pyfastaq >= 3.10.0'],
     license='GPLv3',
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name='bio_assembly_refinement',
-    version='0.3.3',
+    version='0.4.0',
     description='Assembly refinement tools, mostly useful for (but not limited to) pacbio bacterial assembly',
     long_description=read('README.md'),
     packages = find_packages(),


### PR DESCRIPTION
- Separate by tabs in log file
- tidy up setup.py a little
- require new version of pyfastaq that does not depend on numpy